### PR TITLE
Enable debug_mode for GA4 testing

### DIFF
--- a/site_sintonize/templates/base.html
+++ b/site_sintonize/templates/base.html
@@ -24,7 +24,9 @@
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', '{{ GA_MEASUREMENT_ID }}');
+        gtag('config', '{{ GA_MEASUREMENT_ID }}', {
+            'debug_mode': true
+        });
 
         // Funções de rastreamento customizado para eventos
         function trackBurnoutSurvey() {


### PR DESCRIPTION
- Add debug_mode: true to gtag config
- This will help verify events in DebugView
- Temporary for troubleshooting

